### PR TITLE
Update b64.cpp

### DIFF
--- a/tests/b64.cpp
+++ b/tests/b64.cpp
@@ -31,7 +31,7 @@
 TEST(jwtpp, b64)
 {
 	std::vector<uint8_t> in;
-	in.reserve(128);
+	in.resize(128);
 
 	std::string b64;
 


### PR DESCRIPTION
Fixing the `reserve` does not allocate any element bugs This `reserve` function has no effect on the vector size and cannot alter its elements. So `std::generate(std::begin(in), std::end(in), gen);` means nothing in vector. So this test is meaningless.